### PR TITLE
Dispose materials + textures when unfocusing 360s

### DIFF
--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -154,7 +154,14 @@ export class Images360 extends EventDispatcher{
 
 		this.selectingEnabled = false;
 
+		this.focusedImage = image360;
+
 		this.load(image360).then( () => {
+			// Moving fast, already unfocused the sphere before this texture got loaded. Dispose it.
+			if(image360 !== this.focusedImage) {
+				image.texture.disopse();
+				return;
+			}
 			this.sphere.visible = true;
 			this.sphere.material = this.sphere.material.clone();
 			this.sphere.material.map = image360.texture;
@@ -201,8 +208,6 @@ export class Images360 extends EventDispatcher{
 			500
 		);
 
-		this.focusedImage = image360;
-
 		this.viewer.scissorZones[0].scene.images360.forEach((images360) => {
 			if (images360.selectingEnabled && images360.visible) {
 				visibleImages.push(images360);
@@ -231,9 +236,11 @@ export class Images360 extends EventDispatcher{
 			return;
 		}
 
+		if(this.sphere.material !== sm && this.sphere.material !== clearMeshMaterial) {
+			this.sphere.material.map.dispose();
+			this.sphere.material.dispose();
+		}
 
-		this.sphere.material.map = null;
-		this.sphere.material.needsUpdate = true;
 		this.sphere.visible = false;
 
 		this.sphere.material = clearMeshMaterial;

--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -139,6 +139,8 @@ export class Images360 extends EventDispatcher{
 			this.unfocus();
 		}
 
+		this.focusedImage = image360;
+
 		previousView = {
 			controls: previousView.controls ?? this.viewer.controls,
 			position: previousView.position ?? this.viewer.scene.view.position.clone(),
@@ -154,12 +156,11 @@ export class Images360 extends EventDispatcher{
 
 		this.selectingEnabled = false;
 
-		this.focusedImage = image360;
-
 		this.load(image360).then( () => {
-			// Moving fast, already unfocused the sphere before this texture got loaded. Dispose it.
-			if(image360 !== this.focusedImage) {
-				image.texture.disopse();
+			// Moving fast, this sphere isn't focused anymore by the time the texture loads. Dispose the texture.
+			// Or, moving fast, this sphere was unfocused and refocused. Dispose the new texture and keep the old one.
+			if(image360 !== this.focusedImage || (this.sphere.material !== sm && this.sphere.material !== clearMeshMaterial)) {
+				image360.texture.dispose();
 				return;
 			}
 			this.sphere.visible = true;


### PR DESCRIPTION
Memory leak fix, allowing the loading of many 360images, and it will not use up all the RAM.  It will dispose them.

