### PR TITLE
Raycaster fixes

### DIFF
--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -42,7 +42,7 @@ class Image360{
 // To view the changes check this pull request -> https://github.com/powernai/potree/pull/1/files
 export class Images360 extends EventDispatcher{
 
-	constructor(viewer){
+	constructor(viewer, cpmsRaycaster){
 		super();
 
 		this.focusAction = (image)=>{};
@@ -64,6 +64,7 @@ export class Images360 extends EventDispatcher{
 
 		this.focusedImage = null;
 		this.currentlyHovered = null;
+		this.cpmsRaycaster = cpmsRaycaster;
 
 		let elUnfocus = document.createElement("input");
 		elUnfocus.type = "button";
@@ -310,6 +311,12 @@ export class Images360 extends EventDispatcher{
 	}
 
 	handleHovering(viewer){
+		if(this.cpmsRaycaster) {
+			// Check if this 360image set is behind anything else.
+			const raycast = this.cpmsRaycaster.castRay();
+			if(!raycast || raycast.object !== this)
+				return;
+		}
 		let mouse = viewer.inputHandler.mouse;
 		let domElement = viewer.renderer.domElement;
 
@@ -377,7 +384,7 @@ export class Images360 extends EventDispatcher{
 
 export class Images360Loader{
 
-	static async load(url, viewer, params = {}){
+	static async load(url, viewer, cpmsRaycaster, params = {}){
 
 		if(!params.transform){
 			params.transform = {
@@ -392,7 +399,7 @@ export class Images360Loader{
 		let lines = data.coordinates;
 		// let coordinateLines = lines.slice(1);
 
-		let images360 = new Images360(viewer);
+		let images360 = new Images360(viewer, cpmsRaycaster);
 
 		for(let line of lines){
 

--- a/src/navigation/OrbitControls.js
+++ b/src/navigation/OrbitControls.js
@@ -21,7 +21,7 @@ import {EventDispatcher} from "../EventDispatcher.js";
  
 export class OrbitControls extends EventDispatcher{
 	
-	constructor(viewer, scissorZoneIdxs = [0], allowRotation = true){
+	constructor(viewer, scissorZoneIdxs = [0], allowRotation = true, cpmsRaycaster = null){
 		super();
 		
 		this.viewer = viewer;
@@ -33,6 +33,7 @@ export class OrbitControls extends EventDispatcher{
 		this.scissorZoneIdxs = scissorZoneIdxs;
 		// allowRotation=false means that only horizontal mouse drag rotation is allowed, no vertical/scroll rotation.
 		this.allowRotation = allowRotation;
+		this.cpmsRaycaster = cpmsRaycaster;
 		this.sceneControls = new THREE.Scene();
 
 		this.rotationSpeed = 5;
@@ -106,6 +107,12 @@ export class OrbitControls extends EventDispatcher{
 
 		let dblclick = (e) => {
 			if(this.scissorZoneIdxs.includes(e.scissorZoneIdx) && this.doubleClockZoomEnabled){
+				// Make sure pointcloud is not behind anything.
+				if(cpmsRaycaster) {
+					const raycast = cpmsRaycaster.castRay();
+					if(!raycast || !raycast.object || !this.scene.pointclouds.includes(raycast.object.parent))
+						return;
+				}
 				this.zoomToLocation(e.mouse);
 			}
 		};

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -38,8 +38,9 @@ import JSON5 from "../../libs/json5-2.1.3/json5.mjs";
 
 export class Viewer extends EventDispatcher{
 	
-	constructor(domElement, args = {}){
+	constructor(domElement, args = {}, cpmsRaycaster = null){
 		super();
+		this.cpmsRaycaster = cpmsRaycaster;
 
 		this.renderArea = domElement;
 		this.guiLoaded = false;
@@ -1309,14 +1310,14 @@ export class Viewer extends EventDispatcher{
 		// }
 
 		{ // create ORBIT CONTROLS
-			this.orbitControls = new OrbitControls(this, [0], true);
+			this.orbitControls = new OrbitControls(this, [0], true, this.cpmsRaycaster);
 			this.orbitControls.enabled = false;
 			this.orbitControls.addEventListener('start', this.disableAnnotations.bind(this));
 			this.orbitControls.addEventListener('end', this.enableAnnotations.bind(this));
 		}
 
 		{ // create ORBIT CONTROLS 2
-			this.orbitControls2 = new OrbitControls(this, [1], false);
+			this.orbitControls2 = new OrbitControls(this, [1], false, this.cpmsRaycaster);
 			this.orbitControls2.enabled = false;
 			this.orbitControls2.addEventListener('start', this.disableAnnotations.bind(this));
 			this.orbitControls2.addEventListener('end', this.enableAnnotations.bind(this));


### PR DESCRIPTION
Prevent bims from being clicked behind other things, but does not prevent hover highlighting behind other things because there is not a clean way to do that and maybe it does not matter.

Prevent 360 images from being clicked or highlighted behind other things

Prevent 2D images from being clicked or highlighted behind other things

Prevent pointclouds from being double clicked to zoom in behind other things.

Navigation cube and transformation tool are not being considered.

This change relies on another change in the cpms-web repo.