### PR TITLE
Maintain camera when switching between 360 images.

### DIFF
--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -137,15 +137,17 @@ export class Images360 extends EventDispatcher{
 		return this._visible;
 	}
 
-	focus(image360, fromOtherImage = false){
+	focus(image360){
 		if(this.focusedImage !== null){
 			this.unfocus(true);
+		}
+		else {
+			// When moving focus from one image to another, preserve the return position for the camera. Otherwise, set it from the current position.
+			previousView = {};
 		}
 
 		this.focusedImage = image360;
 
-		// When moving focus from one image to another, preserve the return position for the camera. Otherwise, set it from the current position.
-		previousView = fromOtherImage ? previousView : {};
 		previousView = {
 			controls: previousView.controls ?? this.viewer.controls,
 			position: previousView.position ?? this.viewer.scene.view.position.clone(),
@@ -256,11 +258,13 @@ export class Images360 extends EventDispatcher{
 
 		this.sphere.material = clearMeshMaterial;
 
+		/*
 		let pos = this.viewer.scene.view.position;
 		let target = this.viewer.scene.view.getPivot();
 		let dir = target.clone().sub(pos).normalize();
 		let move = dir.multiplyScalar(10);
 		let newCamPos = target.clone().sub(move);
+		*/
 
 		this.viewer.orbitControls.doubleClockZoomEnabled = true;
 		this.viewer.setControls(previousView.controls);

--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -137,13 +137,15 @@ export class Images360 extends EventDispatcher{
 		return this._visible;
 	}
 
-	focus(image360){
+	focus(image360, fromOtherImage = false){
 		if(this.focusedImage !== null){
 			this.unfocus(true);
 		}
 
 		this.focusedImage = image360;
 
+		// When moving focus from one image to another, preserve the return position for the camera. Otherwise, set it from the current position.
+		previousView = fromOtherImage ? previousView : {};
 		previousView = {
 			controls: previousView.controls ?? this.viewer.controls,
 			position: previousView.position ?? this.viewer.scene.view.position.clone(),
@@ -208,13 +210,14 @@ export class Images360 extends EventDispatcher{
 		this.sphere.position.set(pos_vec.x, pos_vec.y, pos_vec.z);
 
 		let target = new THREE.Vector3(pos_vec.x, pos_vec.y, pos_vec.z);
-		let dir = target.clone().sub(this.viewer.scene.view.position).normalize();
+		// Keep the same facing direction when entering/switching between images.
+		let dir = this.viewer.scene.view.direction.clone().normalize();
 		let move = dir.multiplyScalar(0.000001);
 		let newCamPos = target.clone().sub(move);
 
 		this.viewer.scene.view.setView(
 			newCamPos, 
-			newCamPos, // this change is done to not update the look at vector when switched from old to new image. Updated by Varun Veginati
+			target,
 			500
 		);
 

--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -314,12 +314,6 @@ export class Images360 extends EventDispatcher{
 	}
 
 	handleHovering(viewer){
-		if(this.cpmsRaycaster) {
-			// Check if this 360image set is behind anything else.
-			const raycast = this.cpmsRaycaster.castRay();
-			if(!raycast || raycast.object !== this)
-				return;
-		}
 		let mouse = viewer.inputHandler.mouse;
 		let domElement = viewer.renderer.domElement;
 
@@ -331,6 +325,12 @@ export class Images360 extends EventDispatcher{
 				!viewer.scissorZones[i].scene.images360.includes(this)
 			)
 				continue;
+			if(i == 0 && this.cpmsRaycaster) {
+				// Check if this 360image set is behind anything else.
+				const raycast = this.cpmsRaycaster.castRay();
+				if(!raycast || raycast.object !== this)
+					break;
+			}
 			let camera = viewer.getCamera(i);
 			let ray = Potree.Utils.mouseToRay(mouse, camera, 
 				domElement.clientWidth, domElement.clientHeight,


### PR DESCRIPTION
The camera no longer constantly moves back to the original direction when moving from one 360image to the next.

Also, when exiting a 360image, later exits no longer return the camera to the first exit's position.

This change depends on another change in the potree repository.

#2212




