### PR TITLE
Dispose 2D images.

### DIFF
--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -251,7 +251,9 @@ export class Images360 extends EventDispatcher{
 
 		if(this.sphere.material !== sm && this.sphere.material !== clearMeshMaterial) {
 			this.sphere.material.map.dispose();
+			this.sphere.material.map = null;
 			this.sphere.material.dispose();
+			this.sphere.material = null;
 		}
 
 		this.sphere.visible = false;

--- a/src/modules/OrientedImages/OrientedImages.js
+++ b/src/modules/OrientedImages/OrientedImages.js
@@ -418,13 +418,7 @@ export class OrientedImageLoader{
 		const moveToImage = (image) => {
 			console.log("move to image " + image.id);
 
-			const mesh = image.mesh;
-			const newCamPos = image.position.clone();
-			const newCamTarget = mesh.position.clone();
-
-			viewer.scene.view.setView(newCamPos, newCamTarget, 500, () => {
-				orientedImageControls.capture(image);
-			});
+			orientedImageControls.capture(image);
 
 			if(image.texture === null){
 
@@ -437,7 +431,7 @@ export class OrientedImageLoader{
 						if(target.texture === null){
 							target.texture = texture;
 							target.mesh.material.uniforms.tColor.value = texture;
-							mesh.material.needsUpdate = true;
+							target.mesh.material.needsUpdate = true;
 						}
 					}
 				);
@@ -446,9 +440,15 @@ export class OrientedImageLoader{
 				const imagePath = `${imageParamsPath}/../${target.id}`;
 				new THREE.TextureLoader().load(imagePath,
 					(texture) => {
+						// Moving fast, this image isn't focused anymore by the time the texture loads. Dispose the texture.
+						// Or, moving fast, this image was unfocused and refocused. Dispose the new texture and keep the old one.
+						if(target !== orientedImageControls.image || target.texture !== null) {
+							texture.dispose();
+							return;
+						}
 						target.texture = texture;
 						target.mesh.material.uniforms.tColor.value = texture;
-						mesh.material.needsUpdate = true;
+						target.mesh.material.needsUpdate = true;
 					}
 				);
 				


### PR DESCRIPTION
Textures for the 2D images are disposed upon exiting them, and they are also disposed if, upon loading the texture, a different image has already been selected, or the texture for this image has already separately been loaded (if the user was spam-clicking images).

Camera movement logic when going in and out of the image was also moved.

The camera now returns to the previous position and pivot upon exiting instead of the default position and pivot, to match 360Images. But both do not preserve the camera direction, instead pointing the camera directly at the pivot.

This change depends on another pull request in the cpms-web repo.