### PR TITLE
Disable clicking one 2D image from another

### DIFF
--- a/src/modules/OrientedImages/OrientedImages.js
+++ b/src/modules/OrientedImages/OrientedImages.js
@@ -274,6 +274,8 @@ export class OrientedImageLoader{
 
 		let clicked = false;
 		const onMouseMove = (evt) => {
+			if(orientedImageControls.hasSomethingCaptured())
+				return;
 			clicked = false;
 			const tStart = performance.now();
 			if(hoveredElement){
@@ -467,7 +469,8 @@ export class OrientedImageLoader{
 			clicked = true;
 		}
 		const onMouseClick = (evt) => {
-			if (clicked && hoveredElement) {
+			// Clicking from 2D image to 2D image does not currently work. Disabling clicks for now.
+			if (clicked && hoveredElement && !orientedImageControls.hasSomethingCaptured()) {
 				if (orientedImageControls.hasSomethingCaptured()) {
 					orientedImageControls.release();
 				}


### PR DESCRIPTION
Users must now return to 3D view in order to click a new 2D image. They cannot turn the camera to click another one.

The code was not able to properly handle the situation but the situation is not supposed to happen anyway so it is disabled.





