### PR TITLE
Fix image becomes visible with arrowkeys

### DIFF
--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -160,7 +160,8 @@ export class Images360 extends EventDispatcher{
 				image360.texture.dispose();
 				return;
 			}
-			this.sphere.visible = true;
+			if(this.visible)
+				this.sphere.visible = true;
 			this.sphere.material = this.sphere.material.clone();
 			this.sphere.material.map = image360.texture;
 			this.sphere.material.needsUpdate = true;


### PR DESCRIPTION
If the user focuses on a 360image, then toggles 360image visibility off with the checkboxes, then moves to another 360image with the arrow keys, it no longer makes the current 360image visible again.