### PR TITLE
Fix TDImage alignment with pointclouds

### DIFF
--- a/src/Potree.js
+++ b/src/Potree.js
@@ -214,6 +214,10 @@ export function loadPointCloud(path, name, callback){
 			console.error(new Error(`failed to load point cloud from URL: ${path}`));
 		}
 	});
+	promise = promise.then((pointcloud) => {
+		pointcloud.pointcloud.pcoGeometry.offset.set(0,0,0);
+		return pointcloud;
+	});
 
 	if(callback){
 		promise.then(pointcloud => {


### PR DESCRIPTION
Now, if a matched pair of TDImages and pointclouds have the same position, they will be perfectly aligned with each other.

This works by setting pointcloud's offset variable to (0,0,0) to match the TDImages. It would be better if the TDImage was given an offset to match the pointcloud, but there is currently no link between a TDImage and its matching pointcloud to decide which one should take the offset of which.

This change also messes with pointclouds that were manually aligned to the TDImages, because now they're being double-moved and no longer match, so they will have to be fixed. If you just reset the pointcloud and TDImage positions to 0, they will line up.





