### PR TITLE
Fixed some 360image bugs.

### DIFF
--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -72,7 +72,6 @@ export class Images360 extends EventDispatcher{
 		this.cpmsRaycaster = cpmsRaycaster;
 
 		this.onUpdate = () => this.update(viewer);
-		viewer.addEventListener("update", this.onUpdate);
 
 		viewer.inputHandler.addInputListener(this);
 

--- a/src/viewer/Scene.js
+++ b/src/viewer/Scene.js
@@ -218,6 +218,7 @@ export class Scene extends EventDispatcher{
 		 	'scene': this,
 		 	'images': images
 		});
+		images.viewer.addEventListener("update", images.onUpdate);
 	}
 
 	remove360Images(images){


### PR DESCRIPTION
Switching back to the main scene from another view such as crosssection no longer breaks 360images.

Changing the time on the scheduler now changes the 360image that appears in the miniscene according to how it looks in the main scene.

The miniscene now disappears when it is not currently showing anything. This also means it disappears in other views where it is not being used.

This commit depends on a commit to cpms-web.