### PR TITLE
Allow OrbitControls to be restricted to 2D rotate.

### DIFF
--- a/src/viewer/View.js
+++ b/src/viewer/View.js
@@ -54,6 +54,8 @@ export class View{
 
 		//if(dir.x === dir.y){
 		if(dir.x === 0 && dir.y === 0){
+			this.yaw = 0;
+			this.roll = 0;
 			this.pitch = Math.PI / 2 * Math.sign(dir.z);
 		}else{
 			let yaw = Math.atan2(dir.y, dir.x) - Math.PI / 2;

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1269,14 +1269,14 @@ export class Viewer extends EventDispatcher{
 		// }
 
 		{ // create ORBIT CONTROLS
-			this.orbitControls = new OrbitControls(this, [0], true, this.cpmsRaycaster);
+			this.orbitControls = new OrbitControls(this, [0], "all", this.cpmsRaycaster);
 			this.orbitControls.enabled = false;
 			this.orbitControls.addEventListener('start', this.disableAnnotations.bind(this));
 			this.orbitControls.addEventListener('end', this.enableAnnotations.bind(this));
 		}
 
 		{ // create ORBIT CONTROLS 2
-			this.orbitControls2 = new OrbitControls(this, [1], false, this.cpmsRaycaster);
+			this.orbitControls2 = new OrbitControls(this, [1], "z", this.cpmsRaycaster);
 			this.orbitControls2.enabled = false;
 			this.orbitControls2.addEventListener('start', this.disableAnnotations.bind(this));
 			this.orbitControls2.addEventListener('end', this.enableAnnotations.bind(this));


### PR DESCRIPTION
Change boolean allowRotation to string allowedRotation for OrbitControls

allowedRotation = "all" is normal. allowedRotation = "x" or "y" or "z" restricts its rotation to the "x" or "y" or "z" dimensions.

But since it is based on intrinsic angles, it only works if the camera is oriented a certain way. Making it work for all orientations might be messier, and is not necessary.

Used for a pull request in cpms-web.