### PR TITLE
Miniscene-360-spheres-improvements

### DIFF
--- a/src/modules/Images360/Images360.js
+++ b/src/modules/Images360/Images360.js
@@ -59,7 +59,7 @@ export class Images360 extends EventDispatcher{
 		this.node = new THREE.Object3D();
 
 		this.sphere = new THREE.Mesh(sgHigh, sm);
-		this.alternateFocus = false;
+		this.isMiniscene = false;
 		this.sphere.visible = false;
 		this.sphere.scale.set(1000, 1000, 1000);
 		this.node.add(this.sphere);
@@ -78,7 +78,7 @@ export class Images360 extends EventDispatcher{
 		this.focusFunction = () => {
 			if(this.currentlyHovered && this.currentlyHovered.image360) {
 				// calling focus from mini scene's 360 images
-				if (this.alternateFocus) {
+				if (this.isMiniscene) {
 					if (this.companionObject.focusedImage) {
 						let objIdx = this.node.children.indexOf(this.currentlyHovered);
 						this.companionObject.currentlyHovered = this.companionObject.node.children[objIdx];
@@ -170,7 +170,7 @@ export class Images360 extends EventDispatcher{
 			this.sphere.material.map = image360.texture;
 			this.sphere.material.needsUpdate = true;
 		});
-		if (!this.alternateFocus) {
+		if (!this.isMiniscene) {
 			this.sphere.material = clearMeshMaterial;
 		}
 
@@ -254,7 +254,7 @@ export class Images360 extends EventDispatcher{
 		}
 		this.focusedImage = null;
 
-		if(!this.alternateFocus) {
+		if(!this.isMiniscene) {
 			this.sphere.material = sm;
 		}
 
@@ -350,22 +350,22 @@ export class Images360 extends EventDispatcher{
 		return;
 		}
 
-			let intersection = intersections[0];
-			// Highlight the same sphere on other scene. Don't highlight if zoomed into the 360 view.
-			if (intersections.length > 1) {
-				this.currentlyHovered = intersection.object;
-this.currentlyHovered.material = smHovered;
-			}
-			if (this.companionObject && !this.companionObject.focusedImage && this.alternateFocus && intersections.length > 1) {
+		const intersection = intersections[0];
+		// Highlight the same sphere on other scene. Don't highlight if zoomed into the 360 view.
+		if (intersection) {
+			this.currentlyHovered = intersection.object;
+			this.currentlyHovered.material = smHovered;
+			if (this.companionObject && !this.companionObject.focusedImage && this.isMiniscene) {
 				let objIdx = this.node.children.indexOf(intersection.object);
 				this.companionObject.currentlyHovered = this.companionObject.node.children[objIdx];
 				this.companionObject.currentlyHovered.material = smHovered;
 			}
+		}
 
-			//label.visible = true;
-			//label.setText(this.currentlyHovered.image360.file);
-			//this.currentlyHovered.getWorldPosition(label.position);
-			}
+		//label.visible = true;
+		//label.setText(this.currentlyHovered.image360.file);
+		//this.currentlyHovered.getWorldPosition(label.position);
+	}
 
 	update(){
 
@@ -386,6 +386,18 @@ this.currentlyHovered.material = smHovered;
 		}
 		else if(!newVisible && this.visible) {
 			this.hide();
+		}
+		
+		if(this.isMiniscene){
+			const view = viewer.getView(1);
+			const object = this.node;
+			if(view && object) {
+				// Dividing by 25 makes it seem mostly normal at the default view position of z=100.
+				const scale = Math.min(1, (view.position.z - object.position.z) / (object.scale.x * 25));
+				this.node.children.forEach((sphere) => 
+					sphere.scale.set(scale,scale,scale)
+				);
+			}
 		}
 	}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -562,19 +562,14 @@ export class Utils {
 				return null;
 
 		// Position with respect to viewport instead of canvas.
-		let normalizedMouse = {
-			x: ((mouse.x - viewport.x) / viewport.width) * 2 - 1,
-			y: (((height - mouse.y) - viewport.y) / viewport.height) * 2 - 1
-		};
+		let normalizedMouse = new THREE.Vector2(
+			((mouse.x - viewport.x) / viewport.width) * 2 - 1,
+			(((height - mouse.y) - viewport.y) / viewport.height) * 2 - 1
+		);
 
-		let vector = new THREE.Vector3(normalizedMouse.x, normalizedMouse.y, 0.5);
-		let origin = camera.position.clone();
-		vector.unproject(camera);
-		let direction = new THREE.Vector3().subVectors(vector, origin).normalize();
-
-		let ray = new THREE.Ray(origin, direction);
-
-		return ray;
+		const raycaster = new THREE.Raycaster();
+		raycaster.setFromCamera(normalizedMouse, camera);
+		return raycaster.ray;
 	}
 
 	static projectedRadius(radius, camera, distance, screenWidth, screenHeight){

--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -270,6 +270,7 @@ export class Viewer extends EventDispatcher{
 
 		let scene = new Scene(this.renderer);
 		let scene2 = new Scene(this.renderer);
+		scene2.cameraMode = CameraMode.ORTHOGRAPHIC;
 		
 		{ // create VR scene
 			this.sceneVR = new THREE.Scene();


### PR DESCRIPTION
When the user zooms in/out on the miniscene, the spheres grow/shrink to
take up the same constant amount of screen space. There is a max size
that prevents them from turning into a jumble when the user zooms out
too far.

The miniscene's camera is also orthogonal now. This stops the spheres
from moving around in perspective since they are in front of the
background.

This commit matches a commit in cpms-web.